### PR TITLE
remove deprecated call to nullExec

### DIFF
--- a/src/SetAttribute/widget/SetAttribute.js
+++ b/src/SetAttribute/widget/SetAttribute.js
@@ -144,7 +144,9 @@ define([
 
 
             // The callback, coming from update, needs to be executed, to let the page know it finished rendering
-            mendix.lang.nullExec(callback);
+            if (callback) {
+                callback(); 
+            }
         },
 
         _unsubscribe: function() {


### PR DESCRIPTION
The call to nullExec creates the following warnings in the logs files:
DEPRECATED: mendix.lang.nullExec. Use plain javascript if instead -- will be removed in version: 9.0

See https://apidocs.mendix.com/7/client/module-mendix_lang.html#nullExec for more information.